### PR TITLE
Refactor around pubsubconn and subscribers to prevent race conditions

### DIFF
--- a/redisbus/encoder.go
+++ b/redisbus/encoder.go
@@ -1,0 +1,20 @@
+package redisbus
+
+import (
+	"encoding/json"
+)
+
+type MessageEncoder[M any] interface {
+	EncodeMessage(message M) ([]byte, error)
+	DecodeMessage(data []byte, message *M) error
+}
+
+type JSONMessageEncoder[M any] struct{}
+
+func (e JSONMessageEncoder[M]) EncodeMessage(message M) ([]byte, error) {
+	return json.Marshal(message)
+}
+
+func (e JSONMessageEncoder[M]) DecodeMessage(data []byte, message *M) error {
+	return json.Unmarshal(data, message)
+}

--- a/redisbus/redisbus.go
+++ b/redisbus/redisbus.go
@@ -121,7 +121,7 @@ func (r *RedisBus[M]) Run(ctx context.Context) error {
 		}
 		if retry > maxRetries {
 			r.log.Warnf("redisbus: unable to connect after %d retries, giving up: %v", retry, err)
-			return err
+			return fmt.Errorf("redisbus: unable to connect after %d retries", retry)
 		}
 		lastRetry = time.Now().Unix()
 		retry += 1

--- a/redisbus/redisbus.go
+++ b/redisbus/redisbus.go
@@ -2,9 +2,9 @@ package redisbus
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -15,17 +15,21 @@ import (
 )
 
 type RedisBus[M any] struct {
-	log         logger.Logger
-	conn        *redis.Pool
-	psc         *redis.PubSubConn
-	namespace   string
-	encoder     MessageEncoder[M]
-	subscribers map[string][]*subscriber[M]
+	log       logger.Logger
+	pool      *redis.Pool
+	namespace string
+	encoder   MessageEncoder[M]
+
+	psc   *redis.PubSubConn
+	pscMu sync.Mutex
+
+	channels   map[string]map[*subscriber[M]]bool
+	channelsMu sync.Mutex
 
 	ctx     context.Context
 	ctxStop context.CancelFunc
+
 	running int32
-	mu      sync.Mutex
 }
 
 var _ pubsub.PubSub[any] = &RedisBus[any]{}
@@ -35,7 +39,7 @@ var (
 	reconnectOnRecoverableFailureInterval = time.Second * 10
 )
 
-func New[M any](log logger.Logger, conn *redis.Pool, optEncoder ...MessageEncoder[M]) (*RedisBus[M], error) {
+func New[M any](log logger.Logger, pool *redis.Pool, optEncoder ...MessageEncoder[M]) (*RedisBus[M], error) {
 	var encoder MessageEncoder[M]
 	if len(optEncoder) > 0 {
 		encoder = optEncoder[0]
@@ -59,21 +63,21 @@ func New[M any](log logger.Logger, conn *redis.Pool, optEncoder ...MessageEncode
 
 	// Construct the bus object
 	bus := &RedisBus[M]{
-		log:         log,
-		conn:        conn,
-		namespace:   namespace,
-		encoder:     encoder,
-		subscribers: make(map[string][]*subscriber[M], 0),
+		log:       log,
+		pool:      pool,
+		namespace: namespace,
+		encoder:   encoder,
+		channels:  map[string]map[*subscriber[M]]bool{},
 	}
 	return bus, nil
 }
 
 func (r *RedisBus[M]) Run(ctx context.Context) error {
-	if r.conn == nil {
-		return errors.New("redisbus: missing redis connection pool")
-	}
 	if r.IsRunning() {
 		return fmt.Errorf("redisbus: already running")
+	}
+	if r.pool == nil {
+		return errors.New("redisbus: missing redis connection pool")
 	}
 
 	r.ctx, r.ctxStop = context.WithCancel(ctx)
@@ -86,6 +90,7 @@ func (r *RedisBus[M]) Run(ctx context.Context) error {
 	// attempt to reconnect a number of consecutive times, before
 	// stopping attempts and returning an error
 	const maxRetries = 5
+
 	retry := 0
 	lastRetry := time.Now().Unix()
 
@@ -93,26 +98,34 @@ func (r *RedisBus[M]) Run(ctx context.Context) error {
 		select {
 		case <-r.ctx.Done():
 			// in case of shutdown, stop reconnect attempts
+			r.log.Debug("redisbus: service was stopped")
 			return nil
 		default:
 		}
 
-		err := r.connectAndListen(r.ctx)
-		if err != nil {
-			if time.Now().Unix()-int64(time.Duration(time.Minute*3).Seconds()) > lastRetry {
-				retry = 0
-			}
-			if retry >= maxRetries {
-				return err
-			}
-			lastRetry = time.Now().Unix()
-			retry += 1
-		}
-
 		// wait before trying to reconnect to pubsub service
 		delay := time.Second * time.Duration(float64(retry)*3)
-		r.log.Warnf("redisbus: lost connection, pausing for %v, then retrying to connect (attempt #%d)...", delay, retry)
-		time.Sleep(delay)
+		if delay > 0 {
+			r.log.Warnf("redisbus: lost connection, pausing for %v, then retrying to connect (attempt #%d)...", delay, retry)
+			time.Sleep(delay)
+		}
+
+		err := r.connectAndConsume(r.ctx)
+		if err == nil {
+			r.log.Debugf("redisbus: service was stopped")
+			return nil
+		}
+
+		if time.Now().Unix()-int64(time.Duration(time.Minute*3).Seconds()) > lastRetry {
+			retry = 0
+		}
+		if retry > maxRetries {
+			r.log.Warnf("redisbus: unable to connect after %d retries, giving up: %v", retry, err)
+			return err
+		}
+		lastRetry = time.Now().Unix()
+		retry += 1
+		r.log.Debugf("redisbus: unable to connect (retry %d/%d): %v", retry, maxRetries, err)
 	}
 }
 
@@ -121,13 +134,16 @@ func (r *RedisBus[M]) Stop() {
 		return
 	}
 
+	r.channelsMu.Lock()
 	// attempt to unsubscribe all subscribers
-	for _, subscribers := range r.subscribers {
-		for _, sub := range subscribers {
-			sub.Unsubscribe()
+	for channelID, subscribers := range r.channels {
+		for sub := range subscribers {
+			r.cleanUpSubscription(channelID, sub)
 		}
 	}
+	r.channelsMu.Unlock()
 
+	// send stop
 	r.log.Info("redisbus: stop")
 	r.ctxStop()
 }
@@ -146,7 +162,7 @@ func (r *RedisBus[M]) Publish(ctx context.Context, channelID string, message M) 
 		return fmt.Errorf("redisbus: encoding error: %w", err)
 	}
 
-	conn := r.conn.Get()
+	conn := r.pool.Get()
 	defer conn.Close()
 
 	_, err = conn.Do("PUBLISH", r.namespace+channelID, data)
@@ -161,30 +177,9 @@ func (r *RedisBus[M]) Subscribe(ctx context.Context, channelID string) (pubsub.S
 		return nil, fmt.Errorf("redisbus: pubsub is not running")
 	}
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if r.psc == nil {
-		return nil, fmt.Errorf("redisbus: unable to subscribe to channel %q, pubsubconn is not active", channelID)
-	}
-
-	// Redis
-	// TODO: at this time, we use a single redis pubsubconn for all subscriptions.
-	// In the future we could make multiple psc connections in a pool to use for
-	// a bunch of subscriptions.
-	err := r.psc.Subscribe(r.namespace + channelID)
-	if err != nil {
-		return nil, fmt.Errorf("redisbus: failed to subscribe to channel %q: %w", channelID, err)
-	}
-
 	// Pubsub subsystem
-	_, ok := r.subscribers[channelID]
-	if !ok {
-		r.subscribers[channelID] = []*subscriber[M]{}
-	}
-
 	ch := make(chan M)
-	subscriber := &subscriber[M]{
+	sub := &subscriber[M]{
 		pubsub:    r,
 		channelID: channelID,
 		ch:        ch,
@@ -192,36 +187,76 @@ func (r *RedisBus[M]) Subscribe(ctx context.Context, channelID string) (pubsub.S
 		done:      make(chan struct{}),
 	}
 
-	subscriber.unsubscribe = func() {
-		close(subscriber.done)
+	sub.unsubscribe = func() {
+		r.channelsMu.Lock()
+		defer r.channelsMu.Unlock()
 
-		r.mu.Lock()
-		defer r.mu.Unlock()
-
-		close(subscriber.sendCh)
-
-		// flush subscriber.ch so that the MakeUnboundedBuffered goroutine exits
-		for ok := true; ok; _, ok = <-subscriber.ch {
-		}
-
-		for i, sub := range r.subscribers[channelID] {
-			if sub == subscriber {
-				r.subscribers[channelID] = append(r.subscribers[channelID][:i], r.subscribers[channelID][i+1:]...)
-				if len(r.subscribers[channelID]) == 0 {
-					if err := r.psc.Unsubscribe(r.namespace + channelID); err != nil {
-						r.log.Warnf("redisbus: failed to unsubscribe from channel %q: %v", channelID, err)
-					}
-					delete(r.subscribers, channelID)
-				}
-				return
-			}
-		}
-
+		r.cleanUpSubscription(channelID, sub)
 	}
 
-	r.subscribers[channelID] = append(r.subscribers[channelID], subscriber)
+	// add channel and subscription
+	r.channelsMu.Lock()
+	_, ok := r.channels[channelID]
+	if !ok {
+		r.channels[channelID] = map[*subscriber[M]]bool{}
+	}
+	r.channels[channelID][sub] = true
+	r.channelsMu.Unlock()
 
-	return subscriber, nil
+	// Redis
+	// TODO: at this time, we use a single redis pubsubconn for all subscriptions.
+	// In the future we could make multiple psc connections in a pool to use for
+	// a bunch of subscriptions.
+
+	psc, err := r.getPubSubConn()
+	if err != nil {
+		return nil, fmt.Errorf("redisbus: unable to subscribe to channel %q: %w", channelID, err)
+	}
+
+	if err := psc.Subscribe(r.namespace + channelID); err != nil {
+		return nil, fmt.Errorf("redisbus: failed to subscribe to channel %q: %w", channelID, err)
+	}
+
+	return sub, nil
+}
+
+func (r *RedisBus[M]) cleanUpSubscription(channelID string, sub *subscriber[M]) {
+	if len(r.channels[channelID]) < 1 {
+		return
+	}
+	if !r.channels[channelID][sub] {
+		return
+	}
+
+	close(sub.done)
+	close(sub.sendCh)
+
+	// flush subscriber.ch so that the MakeUnboundedBuffered goroutine exits
+	for ok := true; ok; _, ok = <-sub.ch {
+	}
+
+	// remove sub from list of subscribers
+	delete(r.channels[channelID], sub)
+
+	if len(r.channels[channelID]) > 0 {
+		return // channel has more subscriptions, exit here
+	}
+
+	// channel has no more subscribers
+	r.log.Debugf("redisbus: removing channel %q", channelID)
+
+	// delete channel
+	delete(r.channels, channelID)
+
+	// unsubscribe from channel
+	psc, _ := r.getPubSubConn()
+	if psc == nil {
+		return
+	}
+
+	if err := psc.Unsubscribe(r.namespace + channelID); err != nil {
+		r.log.Warnf("redisbus: failed to unsubscribe from channel %q: %v", channelID, err)
+	}
 }
 
 func (r *RedisBus[M]) NumSubscribers(channelID string) (int, error) {
@@ -229,7 +264,7 @@ func (r *RedisBus[M]) NumSubscribers(channelID string) (int, error) {
 		return 0, fmt.Errorf("redisbus: pubsub is not running")
 	}
 
-	conn := r.conn.Get()
+	conn := r.pool.Get()
 	defer conn.Close()
 
 	vs, err := redis.Values(conn.Do("PUBSUB", "NUMSUB", r.namespace+channelID))
@@ -242,43 +277,76 @@ func (r *RedisBus[M]) NumSubscribers(channelID string) (int, error) {
 	return redis.Int(vs[1], nil)
 }
 
-func (r *RedisBus[M]) connectAndListen(ctx context.Context) error {
+func (r *RedisBus[M]) connectAndConsume(ctx context.Context) error {
 	// TODO: at this time, we have a single PubSubConn for all of our subscribers,
 	// but instead we should have some kind of pool, like 20% of our connections (MaxConn etc.)
 	// could be used for just pubsub..
-	psc := redis.PubSubConn{Conn: r.conn.Get()}
-
-	// internal service channel (this is currently only used for pinging)
-	if err := psc.Subscribe("ping"); err != nil {
-		return fmt.Errorf("redisbus: failed to subscribe to ping channel: %w", err)
+	psc, err := newPubSubConn(r.pool.Get())
+	if err != nil {
+		return err
 	}
 
-	r.mu.Lock()
-	r.psc = &psc
-	r.mu.Unlock()
-
+	r.setPubSubConn(psc)
 	defer func() {
-		r.mu.Lock()
-		// psc.Close also closes the underlying r.conn
-		if err := r.psc.Close(); err != nil {
+		if err := psc.Unsubscribe(); err != nil {
+			r.log.Warnf("redisbus: unable to unsubscribe from all channels: %v", err)
+		}
+		if err := psc.Close(); err != nil {
 			r.log.Warnf("redisbus: unable to close pubsub connection gracefully: %v", err)
 		}
-		r.psc = nil
-		r.mu.Unlock()
+		r.setPubSubConn(nil)
 	}()
 
-	r.mu.Lock()
+	r.channelsMu.Lock()
 	// re-subscribing to all channels
-	for channelID := range r.subscribers {
-		if err := r.psc.Subscribe(r.namespace + channelID); err != nil {
+	for channelID := range r.channels {
+		if len(r.channels[channelID]) < 1 {
+			continue
+		}
+		if err := psc.Subscribe(r.namespace + channelID); err != nil {
 			r.log.Warnf("redisbus: failed to re-subscribe to channel %q due to %v", channelID, err)
-			r.mu.Unlock()
+
+			r.channelsMu.Unlock()
 			return err
 		}
 		r.log.Debugf("redisbus: re-subscribed to channel %q", channelID)
 	}
-	r.mu.Unlock()
+	r.channelsMu.Unlock()
 
+	return r.consumeMessages(ctx, psc)
+}
+
+func (r *RedisBus[M]) broadcast(ctx context.Context, channelID string, message M) error {
+	r.channelsMu.Lock()
+	defer r.channelsMu.Unlock()
+
+	subscribers, ok := r.channels[channelID]
+	if !ok {
+		// no subscribers on this channel, which is okay
+
+		// TODO: with redis though, we should have subscribers if we're receiving
+		// this message?  it means the subscribers are out-of-sync, from our
+		// internal chan state and redis bus
+		return nil
+	}
+
+	for sub, ok := range subscribers {
+		if !ok {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			// ok
+		case <-sub.done:
+			// ok
+		case sub.sendCh <- message:
+		}
+	}
+
+	return nil
+}
+
+func (r *RedisBus[M]) consumeMessages(ctx context.Context, psc *redis.PubSubConn) error {
 	errCh := make(chan error, 1)
 
 	// reading messages
@@ -293,12 +361,11 @@ func (r *RedisBus[M]) connectAndListen(ctx context.Context) error {
 			default:
 			}
 
-			r.mu.Lock()
-			redisRawMsg := r.psc.Receive()
-			r.mu.Unlock()
-
-			switch redisMsg := redisRawMsg.(type) {
+			switch redisMsg := psc.ReceiveContext(ctx).(type) {
 			case error:
+				if os.IsTimeout(redisMsg) {
+					continue // ok
+				}
 				errCh <- redisMsg
 				return
 
@@ -324,7 +391,7 @@ func (r *RedisBus[M]) connectAndListen(ctx context.Context) error {
 
 			case redis.Subscription:
 				if redisMsg.Count > 0 {
-					r.log.Debugf("redisbus: received action %s %s %d", redisMsg.Kind, redisMsg.Channel, redisMsg.Count)
+					r.log.Debugf("redisbus: received action %s on channel %q (%d)", redisMsg.Kind, redisMsg.Channel, redisMsg.Count)
 				}
 
 			case redis.Pong:
@@ -349,68 +416,47 @@ loop:
 
 		case err := <-errCh:
 			if err != nil {
-				return fmt.Errorf("redisbus: received error from pubsub: %w", err)
+				return err
 			}
 			break loop
 
 		case <-ticker.C:
-			r.mu.Lock()
-			err := r.psc.Ping("")
-			r.mu.Unlock()
-
-			if err != nil {
+			if err := psc.Ping(""); err != nil {
 				r.log.Errorf("redisbus: ping health check error: %w", err)
 				break loop
 			}
 		}
 	}
 
-	// Unsubscribe from all channels, it will resubscribe on connect, and
-	// on Stop(), we will force-unsubscribe all, etc.
-	r.mu.Lock()
-	err := r.psc.Unsubscribe()
-	r.mu.Unlock()
-
-	if err != nil {
-		return fmt.Errorf("redisbus: unsubscribe from all channels error: %w", err)
-	}
-
 	return nil
 }
 
-func (r *RedisBus[M]) broadcast(ctx context.Context, channelID string, message M) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+func (r *RedisBus[M]) setPubSubConn(psc *redis.PubSubConn) {
+	r.pscMu.Lock()
+	defer r.pscMu.Unlock()
 
-	_, ok := r.subscribers[channelID]
-	if !ok {
-		// no subscribers on this channel, which is okay
-		// TODO: with redis though, we should have subscribers if we're receiving this message?
-		// it means the subscribers are out-of-sync, from our internal chan state and redis bus
-		return nil
+	r.psc = psc
+}
+
+func (r *RedisBus[M]) getPubSubConn() (*redis.PubSubConn, error) {
+	r.pscMu.Lock()
+	defer r.pscMu.Unlock()
+
+	psc := r.psc
+	if psc == nil {
+		return nil, errors.New("no active pubsubconn")
 	}
 
-	for _, sub := range r.subscribers[channelID] {
-		select {
-		case <-sub.done:
-		case sub.sendCh <- message:
-		}
+	return psc, nil
+}
+
+func newPubSubConn(conn redis.Conn) (*redis.PubSubConn, error) {
+	psc := redis.PubSubConn{Conn: conn}
+
+	// internal service channel (this is currently only used for pinging)
+	if err := psc.Subscribe("ping"); err != nil {
+		return nil, fmt.Errorf("redisbus: failed to subscribe to ping channel: %w", err)
 	}
 
-	return nil
-}
-
-type MessageEncoder[M any] interface {
-	EncodeMessage(message M) ([]byte, error)
-	DecodeMessage(data []byte, message *M) error
-}
-
-type JSONMessageEncoder[M any] struct{}
-
-func (e JSONMessageEncoder[M]) EncodeMessage(message M) ([]byte, error) {
-	return json.Marshal(message)
-}
-
-func (e JSONMessageEncoder[M]) DecodeMessage(data []byte, message *M) error {
-	return json.Unmarshal(data, message)
+	return &psc, nil
 }

--- a/redisbus/redisbus_test.go
+++ b/redisbus/redisbus_test.go
@@ -1,0 +1,318 @@
+package redisbus
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/goware/logger"
+	"github.com/goware/pubsub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type message struct {
+	Body string
+}
+
+func newPool(addr string) *redis.Pool {
+	return &redis.Pool{
+		Dial: func() (redis.Conn, error) {
+			return redis.Dial("tcp", addr)
+		},
+	}
+}
+
+func TestRedisbusStartStop(t *testing.T) {
+	pool := newPool("127.0.0.1:6379")
+
+	bus, err := New[message](logger.NewLogger(logger.LogLevel_DEBUG), pool)
+	assert.NoError(t, err)
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- bus.Run(context.Background())
+	}()
+
+	time.Sleep(time.Second * 1)
+	bus.Stop()
+
+	err = <-runErr
+	assert.NoError(t, err)
+}
+
+func TestRedisbusStartStopRestart(t *testing.T) {
+	pool := newPool("127.0.0.1:6379")
+
+	bus, err := New[message](logger.NewLogger(logger.LogLevel_DEBUG), pool)
+	assert.NoError(t, err)
+
+	{
+		runErr := make(chan error, 1)
+		go func() {
+			runErr <- bus.Run(context.Background())
+		}()
+
+		time.Sleep(time.Second * 1)
+		bus.Stop()
+
+		err = <-runErr
+		assert.NoError(t, err)
+	}
+
+	{
+		runErr := make(chan error, 1)
+		go func() {
+			runErr <- bus.Run(context.Background())
+		}()
+
+		time.Sleep(time.Second * 1)
+		bus.Stop()
+
+		err = <-runErr
+		assert.NoError(t, err)
+	}
+}
+
+func TestRedisbusSendAndUnsubscribe(t *testing.T) {
+	pool := newPool("127.0.0.1:6379")
+
+	bus, err := New[message](logger.NewLogger(logger.LogLevel_DEBUG), pool)
+	assert.NoError(t, err)
+
+	go func() {
+		err := bus.Run(context.Background())
+		if err != nil {
+			require.NoError(t, err)
+		}
+	}()
+	defer bus.Stop()
+
+	time.Sleep(1 * time.Second) // wait for run to start
+
+	sub1, _ := bus.Subscribe(context.Background(), "peter")
+	sub2, _ := bus.Subscribe(context.Background(), "julia")
+	sub3, _ := bus.Subscribe(context.Background(), "julia")
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sub1.Unsubscribe()
+			sub2.Unsubscribe()
+			sub3.Unsubscribe()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestRedisbusSendAndReceiveConcurrently(t *testing.T) {
+	pool := newPool("127.0.0.1:6379")
+
+	bus, err := New[message](logger.NewLogger(logger.LogLevel_DEBUG), pool)
+	assert.NoError(t, err)
+
+	go func() {
+		err := bus.Run(context.Background())
+		if err != nil {
+			require.NoError(t, err)
+		}
+	}()
+	defer bus.Stop()
+
+	time.Sleep(1 * time.Second) // wait for run to start
+
+	const subscribersNum = 20
+	subscribers := make([]pubsub.Subscription[message], subscribersNum)
+
+	for i := 0; i < subscribersNum; i++ {
+		subscribers[i], err = bus.Subscribe(context.Background(), fmt.Sprintf("channel-%d", i))
+		assert.NoError(t, err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < subscribersNum; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			received := <-subscribers[i].ReadMessage()
+			assert.Equal(t, fmt.Sprintf("hello: %d", i), received.Body)
+		}(i)
+
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			err := subscribers[i].SendMessage(context.Background(), message{Body: fmt.Sprintf("hello: %d", i)})
+			assert.NoError(t, err)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestRedisbusOverSendAndReceiveConcurrently(t *testing.T) {
+	pool := newPool("127.0.0.1:6379")
+
+	bus, err := New[message](logger.NewLogger(logger.LogLevel_DEBUG), pool)
+	assert.NoError(t, err)
+
+	go func() {
+		err := bus.Run(context.Background())
+		if err != nil {
+			require.NoError(t, err)
+		}
+	}()
+	defer bus.Stop()
+
+	time.Sleep(1 * time.Second) // wait for run to start
+
+	const subscribersNum = 20
+	subscribers := make([]pubsub.Subscription[message], subscribersNum)
+
+	for i := 0; i < subscribersNum; i++ {
+		subscribers[i], err = bus.Subscribe(context.Background(), fmt.Sprintf("channel-%d", i))
+		assert.NoError(t, err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < subscribersNum; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			received := <-subscribers[i].ReadMessage()
+			assert.Equal(t, fmt.Sprintf("hello: %d", i), received.Body)
+		}(i)
+
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			err := subscribers[i].SendMessage(context.Background(), message{Body: fmt.Sprintf("hello: %d", i)})
+			assert.NoError(t, err)
+
+			err = subscribers[i].SendMessage(context.Background(), message{Body: fmt.Sprintf("hello: %d", i)})
+			assert.NoError(t, err)
+
+			err = subscribers[i].SendMessage(context.Background(), message{Body: fmt.Sprintf("hello: %d", i)})
+			assert.NoError(t, err)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestRedisbusSendAndReceiveConcurrentlyThenStop(t *testing.T) {
+	pool := newPool("127.0.0.1:6379")
+
+	bus, err := New[message](logger.NewLogger(logger.LogLevel_DEBUG), pool)
+	assert.NoError(t, err)
+
+	go func() {
+		err := bus.Run(context.Background())
+		if err != nil {
+			require.NoError(t, err)
+		}
+	}()
+
+	time.Sleep(1 * time.Second) // wait for run to start
+
+	const subscribersNum = 100
+	subscribers := make([]pubsub.Subscription[message], subscribersNum)
+
+	for i := 0; i < subscribersNum; i++ {
+		subscribers[i], err = bus.Subscribe(context.Background(), fmt.Sprintf("channel-%d", i))
+		assert.NoError(t, err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < subscribersNum; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_ = subscribers[i].SendMessage(context.Background(), message{Body: fmt.Sprintf("hello: %d", i)})
+		}(i)
+
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, ok := <-subscribers[i].ReadMessage()
+			if ok {
+				bus.Stop()
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestRedisbusSendLargeAmount(t *testing.T) {
+	// this is a long running test, you may restart redis service while the test
+	// is executing
+
+	pool := newPool("127.0.0.1:6379")
+
+	bus, err := New[message](logger.NewLogger(logger.LogLevel_DEBUG), pool)
+	assert.NoError(t, err)
+
+	go func() {
+		err := bus.Run(context.Background())
+		if err != nil {
+			require.NoError(t, err)
+		}
+	}()
+
+	time.Sleep(1 * time.Second) // wait for run to start
+
+	const subscribersNum = 100
+	subscribers := make([]pubsub.Subscription[message], subscribersNum)
+
+	for i := 0; i < subscribersNum; i++ {
+		subscribers[i], err = bus.Subscribe(context.Background(), fmt.Sprintf("channel-%d", i))
+		require.NoError(t, err)
+	}
+
+	require.Len(t, subscribers, subscribersNum)
+
+	nTickets := 2000
+	tickets := make(chan struct{}, nTickets)
+
+	for i := 0; i < nTickets; i++ {
+		tickets <- struct{}{}
+	}
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < subscribersNum; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for {
+				message, ok := <-subscribers[i].ReadMessage()
+				if !ok {
+					break
+				}
+				t.Logf("message: %v", message)
+			}
+		}(i)
+	}
+
+	testUntil := time.Now().Add(time.Second * 60)
+	for {
+		if time.Now().After(testUntil) {
+			t.Logf("stopping test")
+			bus.Stop()
+			break
+		}
+		for i := 0; i < subscribersNum; i++ {
+			go func(i int, ticket struct{}) {
+				defer func() {
+					tickets <- ticket
+				}()
+				_ = subscribers[i].SendMessage(context.Background(), message{Body: fmt.Sprintf("hello: %d", i)})
+			}(i, <-tickets)
+		}
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
This PR adds additional checks to protect r.psc against concurrent writes.