### PR TITLE
Clean-up and remove remaining data races

### DIFF
--- a/_examples/demo-redisbus-gob/main.go
+++ b/_examples/demo-redisbus-gob/main.go
@@ -6,18 +6,17 @@ import (
 	"log"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/go-redis/redis/v8"
 	"github.com/goware/logger"
 	"github.com/goware/pubsub/redisbus"
 )
 
 func main() {
-	redisPool, err := NewRedisPool("localhost")
-	if err != nil {
-		log.Fatal(err)
-	}
+	redisClient := redis.NewClient(&redis.Options{
+		Addr: "127.0.0.1:6379",
+	})
 
-	bus, err := redisbus.New[Message](logger.NewLogger(logger.LogLevel_DEBUG), redisPool, MessageEncoder[Message]{})
+	bus, err := redisbus.New[Message](logger.NewLogger(logger.LogLevel_DEBUG), redisClient, MessageEncoder[Message]{})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -88,34 +87,4 @@ loop:
 			break loop
 		}
 	}
-}
-
-func NewRedisPool(host string) (*redis.Pool, error) {
-	dialFn := func() (redis.Conn, error) {
-		addr := fmt.Sprintf("%s:%d", host, 6379)
-
-		conn, err := redis.Dial("tcp", addr, redis.DialDatabase(0))
-		if err != nil {
-			return nil, fmt.Errorf("could not dial redis host: %w", err)
-		}
-
-		return conn, nil
-	}
-
-	pool := &redis.Pool{
-		Dial: dialFn,
-		TestOnBorrow: func(conn redis.Conn, t time.Time) error {
-			_, err := conn.Do("PING")
-			return fmt.Errorf("PING failed: %w", err)
-		},
-	}
-
-	conn := pool.Get()
-	defer conn.Close()
-
-	if err := conn.Err(); err != nil {
-		return nil, err
-	}
-
-	return pool, nil
 }

--- a/redisbus/pubsubconn.go
+++ b/redisbus/pubsubconn.go
@@ -72,7 +72,7 @@ func (p *pubSubConn) Done() <-chan struct{} {
 
 func (p *pubSubConn) Close() error {
 	if p == nil {
-		return errors.New("invalid pubsub connection")
+		return errInvalidPubSubConn
 	}
 
 	p.conn.PUnsubscribe(p.ctx)

--- a/redisbus/pubsubconn.go
+++ b/redisbus/pubsubconn.go
@@ -1,0 +1,81 @@
+package redisbus
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-redis/redis/v8"
+)
+
+var errInvalidPubSubConn = errors.New("invalid pubsub connection")
+
+type pubSubConn struct {
+	conn     *redis.PubSub
+	ctx      context.Context
+	ctxClose func()
+
+	namespace string
+}
+
+func (r *RedisBus[M]) newPubSubConn(ctx context.Context, client *redis.Client, namespace string) (*pubSubConn, error) {
+	connCtx, connCtxClose := context.WithCancel(ctx)
+
+	conn := client.Subscribe(connCtx, "ping")
+	if _, err := conn.Receive(connCtx); err != nil {
+		return nil, err
+	}
+
+	return &pubSubConn{
+		conn:     conn,
+		ctx:      connCtx,
+		ctxClose: connCtxClose,
+
+		namespace: namespace,
+	}, nil
+}
+
+func (p *pubSubConn) Subscribe(channel string) error {
+	if p == nil {
+		return errInvalidPubSubConn
+	}
+
+	return p.conn.Subscribe(p.ctx, p.namespace+channel)
+}
+
+func (p *pubSubConn) Unsubscribe(channel string) error {
+	if p == nil {
+		return errInvalidPubSubConn
+	}
+
+	return p.conn.Unsubscribe(p.ctx, p.namespace+channel)
+}
+
+func (p *pubSubConn) Ping() error {
+	if p == nil {
+		return errInvalidPubSubConn
+	}
+
+	return p.conn.Ping(p.ctx, "")
+}
+
+func (p *pubSubConn) Receive() (interface{}, error) {
+	if p == nil {
+		return nil, errInvalidPubSubConn
+	}
+
+	return p.conn.Receive(p.ctx)
+}
+
+func (p *pubSubConn) Done() <-chan struct{} {
+	return p.ctx.Done()
+}
+
+func (p *pubSubConn) Close() error {
+	if p == nil {
+		return errors.New("invalid pubsub connection")
+	}
+
+	p.conn.PUnsubscribe(p.ctx)
+	p.ctxClose()
+	return p.conn.Close()
+}

--- a/redisbus/redisbus.go
+++ b/redisbus/redisbus.go
@@ -224,16 +224,13 @@ func (r *RedisBus[M]) NumSubscribers(channelID string) (int, error) {
 		return 0, fmt.Errorf("redisbus: pubsub is not running")
 	}
 
-	vs, err := r.client.PubSubNumSub(r.ctx, r.namespace+channelID).Result()
-	// vs, err := redis.Values(conn.Do("PUBSUB", "NUMSUB", r.namespace+channelID))
+	redisChannel := r.namespace + channelID
+
+	res, err := r.client.PubSubNumSub(r.ctx, redisChannel).Result()
 	if err != nil {
 		return 0, fmt.Errorf("redisbus: failed to retrive subscriber count: %w", err)
 	}
-	if len(vs) < 2 {
-		return 0, nil
-	}
-	return 0, nil
-	// return redis.Int(vs[1], nil)
+	return int(res[redisChannel]), nil
 }
 
 func (r *RedisBus[M]) connectAndConsume(ctx context.Context) error {

--- a/redisbus/redisbus.go
+++ b/redisbus/redisbus.go
@@ -289,10 +289,6 @@ func (r *RedisBus[M]) consumeMessages(psc *pubSubConn) error {
 
 			msg, err := psc.Receive()
 			if err != nil {
-				// TODO: timeout review..?
-				// if os.IsTimeout(redisMsg) {
-				// 	continue // ok
-				// }
 				errCh <- err
 				return
 			}

--- a/redisbus/redisbus_test.go
+++ b/redisbus/redisbus_test.go
@@ -3,6 +3,7 @@ package redisbus
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sync"
 	"testing"
 	"time"
@@ -14,30 +15,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type message struct {
+type messageEnvelope struct {
 	Body string
 }
 
-// func newPool(addr string) *redis.Pool {
-// 	return &redis.Pool{
-// 		Dial: func() (redis.Conn, error) {
-// 			return redis.Dial("tcp", addr)
-// 		},
-// 	}
-// }
-
-func newRedisClient(addr string) *redis.Client {
+func newRedisTestClient() *redis.Client {
+	const addr = "127.0.0.1:6379"
 	return redis.NewClient(&redis.Options{
 		Addr: addr,
-		DB:   0,
 	})
 }
 
 func TestRedisbusStartStop(t *testing.T) {
-	pool := newRedisClient("127.0.0.1:6379")
+	pool := newRedisTestClient()
 
-	bus, err := New[message](logger.NewLogger(logger.LogLevel_DEBUG), pool)
-	assert.NoError(t, err)
+	bus, err := New[messageEnvelope](logger.NewLogger(logger.LogLevel_DEBUG), pool)
+	require.NoError(t, err)
 
 	runErr := make(chan error, 1)
 	go func() {
@@ -52,10 +45,10 @@ func TestRedisbusStartStop(t *testing.T) {
 }
 
 func TestRedisbusStartStopRestart(t *testing.T) {
-	pool := newRedisClient("127.0.0.1:6379")
+	pool := newRedisTestClient()
 
-	bus, err := New[message](logger.NewLogger(logger.LogLevel_DEBUG), pool)
-	assert.NoError(t, err)
+	bus, err := New[messageEnvelope](logger.NewLogger(logger.LogLevel_DEBUG), pool)
+	require.NoError(t, err)
 
 	{
 		runErr := make(chan error, 1)
@@ -79,30 +72,31 @@ func TestRedisbusStartStopRestart(t *testing.T) {
 		time.Sleep(time.Second * 1)
 		bus.Stop()
 
-		err = <-runErr
-		assert.NoError(t, err)
+		assert.NoError(t, <-runErr)
 	}
 }
 
 func TestRedisbusSendAndUnsubscribe(t *testing.T) {
-	pool := newRedisClient("127.0.0.1:6379")
+	pool := newRedisTestClient()
 
-	bus, err := New[message](logger.NewLogger(logger.LogLevel_DEBUG), pool)
-	assert.NoError(t, err)
+	bus, err := New[messageEnvelope](logger.NewLogger(logger.LogLevel_DEBUG), pool)
+	require.NoError(t, err)
 
+	runErr := make(chan error, 1)
 	go func() {
-		err := bus.Run(context.Background())
-		if err != nil {
-			require.NoError(t, err)
-		}
+		runErr <- bus.Run(context.Background())
 	}()
-	defer bus.Stop()
 
 	time.Sleep(1 * time.Second) // wait for run to start
 
-	sub1, _ := bus.Subscribe(context.Background(), "peter")
-	sub2, _ := bus.Subscribe(context.Background(), "julia")
-	sub3, _ := bus.Subscribe(context.Background(), "julia")
+	sub1, err := bus.Subscribe(context.Background(), "peter")
+	require.NoError(t, err)
+
+	sub2, err := bus.Subscribe(context.Background(), "julia")
+	require.NoError(t, err)
+
+	sub3, err := bus.Subscribe(context.Background(), "julia")
+	require.NoError(t, err)
 
 	var wg sync.WaitGroup
 
@@ -116,30 +110,31 @@ func TestRedisbusSendAndUnsubscribe(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+
+	bus.Stop()
+
+	require.NoError(t, <-runErr)
 }
 
 func TestRedisbusSendAndReceiveConcurrently(t *testing.T) {
-	pool := newRedisClient("127.0.0.1:6379")
+	pool := newRedisTestClient()
 
-	bus, err := New[message](logger.NewLogger(logger.LogLevel_DEBUG), pool)
-	assert.NoError(t, err)
+	bus, err := New[messageEnvelope](logger.NewLogger(logger.LogLevel_DEBUG), pool)
+	require.NoError(t, err)
 
+	runErr := make(chan error, 1)
 	go func() {
-		err := bus.Run(context.Background())
-		if err != nil {
-			require.NoError(t, err)
-		}
+		runErr <- bus.Run(context.Background())
 	}()
-	defer bus.Stop()
 
 	time.Sleep(1 * time.Second) // wait for run to start
 
 	const subscribersNum = 20
-	subscribers := make([]pubsub.Subscription[message], subscribersNum)
+	subscribers := make([]pubsub.Subscription[messageEnvelope], subscribersNum)
 
 	for i := 0; i < subscribersNum; i++ {
 		subscribers[i], err = bus.Subscribe(context.Background(), fmt.Sprintf("channel-%d", i))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	var wg sync.WaitGroup
@@ -154,35 +149,36 @@ func TestRedisbusSendAndReceiveConcurrently(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			err := subscribers[i].SendMessage(context.Background(), message{Body: fmt.Sprintf("hello: %d", i)})
+			err := subscribers[i].SendMessage(context.Background(), messageEnvelope{Body: fmt.Sprintf("hello: %d", i)})
 			assert.NoError(t, err)
 		}(i)
 	}
 	wg.Wait()
+
+	bus.Stop()
+
+	require.NoError(t, <-runErr)
 }
 
 func TestRedisbusOverSendAndReceiveConcurrently(t *testing.T) {
-	pool := newRedisClient("127.0.0.1:6379")
+	pool := newRedisTestClient()
 
-	bus, err := New[message](logger.NewLogger(logger.LogLevel_DEBUG), pool)
-	assert.NoError(t, err)
+	bus, err := New[messageEnvelope](logger.NewLogger(logger.LogLevel_DEBUG), pool)
+	require.NoError(t, err)
 
+	runErr := make(chan error, 1)
 	go func() {
-		err := bus.Run(context.Background())
-		if err != nil {
-			require.NoError(t, err)
-		}
+		runErr <- bus.Run(context.Background())
 	}()
-	defer bus.Stop()
 
 	time.Sleep(1 * time.Second) // wait for run to start
 
 	const subscribersNum = 20
-	subscribers := make([]pubsub.Subscription[message], subscribersNum)
+	subscribers := make([]pubsub.Subscription[messageEnvelope], subscribersNum)
 
 	for i := 0; i < subscribersNum; i++ {
 		subscribers[i], err = bus.Subscribe(context.Background(), fmt.Sprintf("channel-%d", i))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	var wg sync.WaitGroup
@@ -197,40 +193,42 @@ func TestRedisbusOverSendAndReceiveConcurrently(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			err := subscribers[i].SendMessage(context.Background(), message{Body: fmt.Sprintf("hello: %d", i)})
+			err := subscribers[i].SendMessage(context.Background(), messageEnvelope{Body: fmt.Sprintf("hello: %d", i)})
 			assert.NoError(t, err)
 
-			err = subscribers[i].SendMessage(context.Background(), message{Body: fmt.Sprintf("hello: %d", i)})
+			err = subscribers[i].SendMessage(context.Background(), messageEnvelope{Body: fmt.Sprintf("hello: %d", i)})
 			assert.NoError(t, err)
 
-			err = subscribers[i].SendMessage(context.Background(), message{Body: fmt.Sprintf("hello: %d", i)})
+			err = subscribers[i].SendMessage(context.Background(), messageEnvelope{Body: fmt.Sprintf("hello: %d", i)})
 			assert.NoError(t, err)
 		}(i)
 	}
 	wg.Wait()
+
+	bus.Stop()
+
+	require.NoError(t, <-runErr)
 }
 
 func TestRedisbusSendAndReceiveConcurrentlyThenStop(t *testing.T) {
-	pool := newRedisClient("127.0.0.1:6379")
+	pool := newRedisTestClient()
 
-	bus, err := New[message](logger.NewLogger(logger.LogLevel_DEBUG), pool)
-	assert.NoError(t, err)
+	bus, err := New[messageEnvelope](logger.NewLogger(logger.LogLevel_DEBUG), pool)
+	require.NoError(t, err)
 
+	runErr := make(chan error, 1)
 	go func() {
-		err := bus.Run(context.Background())
-		if err != nil {
-			require.NoError(t, err)
-		}
+		runErr <- bus.Run(context.Background())
 	}()
 
 	time.Sleep(1 * time.Second) // wait for run to start
 
 	const subscribersNum = 100
-	subscribers := make([]pubsub.Subscription[message], subscribersNum)
+	subscribers := make([]pubsub.Subscription[messageEnvelope], subscribersNum)
 
 	for i := 0; i < subscribersNum; i++ {
 		subscribers[i], err = bus.Subscribe(context.Background(), fmt.Sprintf("channel-%d", i))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	var wg sync.WaitGroup
@@ -238,7 +236,7 @@ func TestRedisbusSendAndReceiveConcurrentlyThenStop(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			_ = subscribers[i].SendMessage(context.Background(), message{Body: fmt.Sprintf("hello: %d", i)})
+			_ = subscribers[i].SendMessage(context.Background(), messageEnvelope{Body: fmt.Sprintf("hello: %d", i)})
 		}(i)
 
 		wg.Add(1)
@@ -251,75 +249,134 @@ func TestRedisbusSendAndReceiveConcurrentlyThenStop(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+
+	require.NoError(t, <-runErr)
 }
 
 func TestRedisbusSendLargeAmount(t *testing.T) {
 	// this is a long running test, you may restart redis service while the test
 	// is executing
 
-	pool := newRedisClient("127.0.0.1:6379")
+	pool := newRedisTestClient()
 
-	bus, err := New[message](logger.NewLogger(logger.LogLevel_DEBUG), pool)
-	assert.NoError(t, err)
+	bus, err := New[messageEnvelope](logger.NewLogger(logger.LogLevel_DEBUG), pool)
+	require.NoError(t, err)
 
+	runErr := make(chan error, 1)
 	go func() {
-		err := bus.Run(context.Background())
-		if err != nil {
-			require.NoError(t, err)
-		}
+		runErr <- bus.Run(context.Background())
 	}()
 
 	time.Sleep(1 * time.Second) // wait for run to start
 
-	const subscribersNum = 100
-	subscribers := make([]pubsub.Subscription[message], subscribersNum)
+	const subscribersNum = 50
+	subscribers := make([]pubsub.Subscription[messageEnvelope], subscribersNum)
 
 	for i := 0; i < subscribersNum; i++ {
-		subscribers[i], err = bus.Subscribe(context.Background(), fmt.Sprintf("channel-%d", i))
+		subscribers[i], err = bus.Subscribe(context.Background(), fmt.Sprintf("channel-%03d", i))
 		require.NoError(t, err)
 	}
 
 	require.Len(t, subscribers, subscribersNum)
 
-	nTickets := 2000
+	nTickets := subscribersNum * 100 // 100x more messages than subscribers
 	tickets := make(chan struct{}, nTickets)
 
 	for i := 0; i < nTickets; i++ {
 		tickets <- struct{}{}
 	}
 
+	var messages = map[string]bool{}
+	var messagesSent, messagesReceived int
+	var stoppedSending bool
+	var messagesMu sync.Mutex
+
 	var wg sync.WaitGroup
 
+	// receive messages
 	for i := 0; i < subscribersNum; i++ {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
 			for {
+
+				messagesMu.Lock()
+				completed := stoppedSending && messagesReceived >= messagesSent
+				t.Logf("received: %d, sent: %d", messagesReceived, messagesSent)
+				messagesMu.Unlock()
+
+				if completed {
+					bus.Stop()
+					return
+				}
+
 				message, ok := <-subscribers[i].ReadMessage()
 				if !ok {
-					break
+					return
 				}
-				t.Logf("message: %v", message)
+
+				t.Logf("received: %#v", message.Body)
+
+				messagesMu.Lock()
+				value, exists := messages[message.Body]
+
+				assert.True(t, exists) // message was sent
+				assert.False(t, value) // message was received once
+
+				messages[message.Body] = true // set as received
+				messagesReceived++
+				messagesMu.Unlock()
 			}
 		}(i)
 	}
 
+	// send messages
 	testUntil := time.Now().Add(time.Second * 60)
 	for {
 		if time.Now().After(testUntil) {
-			t.Logf("stopping test")
-			bus.Stop()
+			t.Logf("stop sending")
+			messagesMu.Lock()
+			stoppedSending = true
+			messagesMu.Unlock()
 			break
 		}
+
 		for i := 0; i < subscribersNum; i++ {
 			go func(i int, ticket struct{}) {
 				defer func() {
 					tickets <- ticket
 				}()
-				_ = subscribers[i].SendMessage(context.Background(), message{Body: fmt.Sprintf("hello: %d", i)})
+
+				var message string
+
+				messagesMu.Lock()
+				for {
+					message = fmt.Sprintf("message: %d", rand.Int63())
+					if _, ok := messages[message]; !ok { // make sure message is unique
+						break
+					}
+				}
+				messages[message] = false // record message in map
+				messagesSent++
+				messagesMu.Unlock()
+
+				err := subscribers[i].SendMessage(context.Background(), messageEnvelope{Body: message})
+				assert.NoError(t, err)
+
 			}(i, <-tickets)
 		}
 	}
 
+	require.True(t, stoppedSending)
+
 	wg.Wait()
+
+	require.NoError(t, <-runErr)
+
+	assert.Equal(t, messagesSent, messagesReceived)
+
+	// make sure there are no lost messages
+	for _, received := range messages {
+		assert.True(t, received)
+	}
 }


### PR DESCRIPTION
There were some rare data races remaining like

```
==================
WARNING: DATA RACE
Write at 0x00c000178038 by goroutine 9:
  github.com/goware/pubsub/redisbus.(*RedisBus[...]).connectAndConsume.func1()
      /home/vagrant/projects/goware/pubsub/redisbus/redisbus.go:275 +0xbc
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:476 +0x32
  github.com/goware/pubsub/redisbus.(*RedisBus[...]).Run()
      /home/vagrant/projects/goware/pubsub/redisbus/redisbus.go:116 +0x6be
  github.com/goware/pubsub/redisbus.TestRedisbusSendLargeAmount.func1()
      /home/vagrant/projects/goware/pubsub/redisbus/redisbus_test.go:267 +0x5a

Previous read at 0x00c000178038 by goroutine 11:
  github.com/goware/pubsub/redisbus.(*RedisBus[...]).consumeMessages.func1()
      /home/vagrant/projects/goware/pubsub/redisbus/redisbus.go:354 +0x109

Goroutine 9 (running) created at:
  github.com/goware/pubsub/redisbus.TestRedisbusSendLargeAmount()
      /home/vagrant/projects/goware/pubsub/redisbus/redisbus_test.go:266 +0x471
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47
```

This PR will remove those data races and clean up the package